### PR TITLE
DisplayManager: turn on display when boot manager finishes the boot agai...

### DIFF
--- a/Src/base/DisplayManager.cpp
+++ b/Src/base/DisplayManager.cpp
@@ -2534,6 +2534,11 @@ void DisplayManager::slotAlsEnabled (bool enable)
 void DisplayManager::markBootFinished(bool finished)
 {
 	if (finished) {
+		// If boot was already finished before we have to deal with a restart of the
+		// whole UI hére and therefore turning on the display
+		if (m_bootFinished)
+			on();
+
 		m_bootFinished = true;
 		if (currentState() == DisplayStateOn
 				|| currentState() == DisplayStateOnLocked


### PR DESCRIPTION
...n

When the compositor goes down the boot manager will now cycle through startup state again
to correctly launch all things again and we have to turn the display on at this time to
make sure the compositor is back in sync with us.

Signed-off-by: Simon Busch morphis@gravedo.de
