### PR TITLE
replace cjson with json-c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ pkg_check_modules(LUNA_PREFS luna-prefs REQUIRED)
 pkg_check_modules(NYX nyx REQUIRED)
 pkg_check_modules(PBNJSON_CPP pbnjson_cpp REQUIRED)
 pkg_check_modules(PBNJSON_C pbnjson_c REQUIRED)
-pkg_check_modules(CJSON cjson REQUIRED)
+pkg_check_modules(JSON json-c REQUIRED)
 pkg_check_modules(SQLITE3 sqlite3 REQUIRED)
 pkg_check_modules(OPENSSL openssl REQUIRED)
 pkg_check_modules(SERVICEINSTALLER serviceinstaller REQUIRED)
@@ -62,7 +62,7 @@ include_directories(
     ${NYX_INCLUDE_DIRS}
     ${PBNJSON_CPP_INCLUDE_DIRS}
     ${SQLITE3_INCLUDE_DIRS}
-    ${CJSON_INCLUDE_DIRS}
+    ${JSON_INCLUDE_DIRS}
     ${OPENSSL_INCLUDE_DIRS}
     ${SERVICEINSTALLER_INCLUDE_DIRS}
     ${PMLOGLIB_INCLUDE_DIRS}
@@ -112,7 +112,7 @@ target_link_libraries(LunaSysMgr
     ${PBNJSON_C_LIBRARIES}
     ${PBNJSON_CPP_LIBRARIES}
     ${SQLITE3_LIBRARIES}
-    ${CJSON_LIBRARIES}
+    ${JSON_LIBRARIES}
     ${OPENSSL_LIBRARIES}
     ${SERVICEINSTALLER_LIBRARIES}
     ${PMLOGLIB_LIBRARIES}

--- a/Src/base/AmbientLightSensor.cpp
+++ b/Src/base/AmbientLightSensor.cpp
@@ -28,7 +28,7 @@
 #include "SystemService.h"
 #include "Time.h"
 
-#include <cjson/json.h>
+#include <json.h>
 #include <glib.h>
 #if defined(HAS_LUNA_PREF)
 #include <lunaprefs.h>

--- a/Src/base/DisplayManager.cpp
+++ b/Src/base/DisplayManager.cpp
@@ -42,7 +42,7 @@
 
 #include <SysMgrDeviceKeydefs.h>
 
-#include <cjson/json.h>
+#include <json.h>
 
 #include <glib.h>
 #include <lunaservice.h>

--- a/Src/base/EASPolicyManager.h
+++ b/Src/base/EASPolicyManager.h
@@ -25,7 +25,7 @@
 #include "Common.h"
 
 #include <string>
-#include "cjson/json.h"
+#include <json.h>
 #include "PtrArray.h"
 
 #include <lunaservice.h>

--- a/Src/base/HapticsController.cpp
+++ b/Src/base/HapticsController.cpp
@@ -24,7 +24,7 @@
 #include "HostBase.h"
 #include "JSONUtils.h"
 #include "Time.h"
-#include "cjson/json.h"
+#include <json.h>
 
 #include <glib.h>
 #include <lunaservice.h>

--- a/Src/base/Security.h
+++ b/Src/base/Security.h
@@ -28,7 +28,7 @@
 
 #include <lunaservice.h>
 
-#include "cjson/json.h"
+#include <json.h>
 
 #include <QObject>
 #include <QString>

--- a/Src/base/SuspendBlocker.cpp
+++ b/Src/base/SuspendBlocker.cpp
@@ -26,7 +26,7 @@
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
-#include <cjson/json.h>
+#include <json.h>
 
 static int s_counter = 0;
 static pthread_mutex_t s_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/Src/base/SystemService.cpp
+++ b/Src/base/SystemService.cpp
@@ -45,7 +45,7 @@
 #include "Security.h"
 #include "EASPolicyManager.h"
 
-#include "cjson/json.h"
+#include <json.h>
 #include <pbnjson.hpp>
 #include "JSONUtils.h"
 
@@ -3348,30 +3348,32 @@ bool cbMonitorProcessMemory(LSHandle* lsHandle, LSMessage *message, void *user_d
 
 	// iterate through the elements and find the pid and the
 	// memory maximum
-	json_object_object_foreach(root, key, val)
 	{
-		if (strcmp(key, "pid") == 0)
+		json_object_object_foreach(root, key, val)
 		{
-			if (json_object_is_type(val, json_type_int))
+			if (strcmp(key, "pid") == 0)
 			{
-				pid = json_object_get_int(val);
+				if (json_object_is_type(val, json_type_int))
+				{
+					pid = json_object_get_int(val);
+				}
+				else
+				{
+					success = false;
+					goto Done;
+				}
 			}
-			else
+			if (strcmp(key, "maxMemory") == 0)
 			{
-				success = false;
-				goto Done;
-			}
-		}
-		if (strcmp(key, "maxMemory") == 0)
-		{
-			if (json_object_is_type(val, json_type_int))
-			{
-				memMax = json_object_get_int(val);
-			}
-			else
-			{
-				success = false;
-				goto Done;
+				if (json_object_is_type(val, json_type_int))
+				{
+					memMax = json_object_get_int(val);
+				}
+				else
+				{
+					success = false;
+					goto Done;
+				}
 			}
 		}
 	}
@@ -3478,31 +3480,33 @@ bool cbEnableFpsCounter(LSHandle* lsHandle, LSMessage *message, void *user_data)
 
 
 	// iterate through the elements
-	json_object_object_foreach(root, key, val)
 	{
-		if (strcmp(key, "enable") == 0)
+		json_object_object_foreach(root, key, val)
 		{
-			label = json_object_object_get(root, "enable");
+			if (strcmp(key, "enable") == 0)
+			{
+				label = json_object_object_get(root, "enable");
 
-			if (label && json_object_is_type(label, json_type_boolean))
+				if (label && json_object_is_type(label, json_type_boolean))
+				{
+					//WindowServer::enableFpsCounter(json_object_get_boolean(label));
+					failed = false;
+				}
+			}
+			if (strcmp(key, "reset") == 0)
 			{
-                // WindowServer::enableFpsCounter(json_object_get_boolean(label));
+				if (json_object_is_type(val, json_type_int))
+				{
+					reset = json_object_get_int(val);
+					// WindowServer::resetFpsBuffer(reset);
+					failed = false;
+				}
+			}
+			if (strcmp(key, "dump") == 0)
+			{
+				// WindowServer::dumpFpsHistory();
 				failed = false;
 			}
-		}
-		if (strcmp(key, "reset") == 0)
-		{
-			if (json_object_is_type(val, json_type_int))
-			{
-				reset = json_object_get_int(val);
-                // WindowServer::resetFpsBuffer(reset);
-				failed = false;
-			}
-		}
-		if (strcmp(key, "dump") == 0)
-		{
-            // WindowServer::dumpFpsHistory();
-			failed = false;
 		}
 	}
 	
@@ -3553,17 +3557,19 @@ bool cbEnableTouchPlot(LSHandle* lsHandle, LSMessage *message, void *user_data)
 		goto Done;
 
 //	// iterate through the elements
-//	json_object_object_foreach(root, key, val)
 //	{
-//		for(uint i = 0; i < sizeof(touchPlotOptions)/sizeof(touchPlotOptions[0]); i++) {
-//			if (strcmp(key, touchPlotOptions[i].name) == 0)
-//			{
-//				label = json_object_object_get(root, touchPlotOptions[i].name);
-
-//				if (label && json_object_is_type(label, json_type_boolean))
+//		json_object_object_foreach(root, key, val)
+//		{
+//			for(uint i = 0; i < sizeof(touchPlotOptions)/sizeof(touchPlotOptions[0]); i++) {
+//				if (strcmp(key, touchPlotOptions[i].name) == 0)
 //				{
-//                    // WindowServer::enableTouchPlotOption(touchPlotOptions[i].type, json_object_get_boolean(label));
-//					failed = false;
+//					label = json_object_object_get(root, touchPlotOptions[i].name);
+
+//					if (label && json_object_is_type(label, json_type_boolean))
+//					{
+//						// WindowServer::enableTouchPlotOption(touchPlotOptions[i].type, json_object_get_boolean(label));
+//						failed = false;
+//					}
 //				}
 //			}
 //		}


### PR DESCRIPTION
- Call json_object_object_foreach only inside own  block
  Otherwise it fails with couple errors like this:
  In file included from sysroots/qemux86/usr/include/cjson/linkhash.h:16:0,
  |                  from sysroots/qemux86/usr/include/cjson/json.h:22,
  |                  from Src/base/Security.h:31,
  |                  from Src/base/SystemService.cpp:50:
  | Src/base/SystemService.cpp:3626:2: error:   crosses initialization of
    'lh_entry\* entry_nextkey'
  |   json_object_object_foreach(root, key, val)
  |   ^
  | Src/base/SystemService.cpp: In function 'bool cbEnableTouchPlot(LSHandle_,
    LSMessage_, void*)':
  | Src/base/SystemService.cpp:3717:1: warning: jump to label 'Done'
    [-fpermissive]
  |  Done:
  |  ^
  | Src/base/SystemService.cpp:3698:8: warning:   from here [-fpermissive]
  |    goto Done;
  |         ^
