### PR TITLE
Add alert service method to display manager

### DIFF
--- a/Src/base/DisplayManager.h
+++ b/Src/base/DisplayManager.h
@@ -134,6 +134,7 @@ public:
     static bool controlCallStatus(LSHandle *sh, LSMessage *message, void *ctx);
 	static bool controlLockStatus(LSHandle *sh, LSMessage *message, void *ctx);
 	static bool controlSetLockStatus(LSHandle *sh, LSMessage *message, void *ctx);
+    static bool controlAlert(LSHandle *sh, LSMessage *message, void *ctx);
 
     // service callbacks
     static bool timeoutCallback(LSHandle *sh, LSMessage *message, void *ctx);


### PR DESCRIPTION
In certain cituations the display needs to be triggered to turn its state and we now
expose the already existing logic for this over ls2.

Signed-off-by: Simon Busch morphis@gravedo.de
