### PR TITLE
Add GridUnit value for emulator

### DIFF
--- a/conf/luna-qemux86.conf
+++ b/conf/luna-qemux86.conf
@@ -34,6 +34,7 @@ ModalWindowWidth=320
 ModalWindowHeight=480
 EnableSplashBackgrounds=false
 SplashIconSize=192
+GridUnit=10
 
 [VirtualKeyboard]
 VirtualKeyboardEnabled=true


### PR DESCRIPTION
Set it to 10 just like for TP instead of default 8, since they both have a 1024*768 resolution
