### PR TITLE
Disable call to postNovacomStatus

### DIFF
--- a/Src/base/SystemService.cpp
+++ b/Src/base/SystemService.cpp
@@ -359,7 +359,8 @@ void SystemService::startService()
 	if (!result)
 		goto Done;
 
-	postNovacomStatus();
+	//We don't have com.palm.accountservices available, so it doesn't make much sense to do the call to postNovacomStatus either
+	//postNovacomStatus();
 
 Done:
 


### PR DESCRIPTION
Since we don't have com.palm.accountservices available
