### PR TITLE
com.palm.luna.perm.json: Add network.internal for com.palm.systemmanager

### DIFF
--- a/files/sysbus/com.palm.luna.perm.json
+++ b/files/sysbus/com.palm.luna.perm.json
@@ -23,6 +23,7 @@
     "com.palm.systemmanager": [
         "applications",
         "devices",
+        "networking.internal",
         "services",
         "settings",
         "system"
@@ -44,10 +45,10 @@
     "com.palm.display": [
         "applications",
         "devices",
+        "networking.internal",
         "services",
         "settings",
-        "system",
-        "networking.internal"
+        "system"
     ],
     "com.palm.keys": [
         "applications",


### PR DESCRIPTION
Fixes:

Jun 23 14:32:42 qemux86-64 webos-telephonyd[502]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.systemmanager","CATEGORY":"/","METHOD":"subscribe"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>