### PR TITLE
luna-sysmgr: Remove references to org.webosports.luna

### DIFF
--- a/Src/base/DisplayManager.cpp
+++ b/Src/base/DisplayManager.cpp
@@ -2975,6 +2975,7 @@ void DisplayManager::backlightOffCallback (void *ctx)
     dm->m_backlightIsOn = false;
 }
 
+/* FIXME this needs rework somehow for luna-surfacemanager
 void DisplayManager::updateCompositorDisplayState(bool on, LSMethodFunction cb , void *context)
 {
     g_debug("%s: on %d", __PRETTY_FUNCTION__, on);
@@ -2988,6 +2989,7 @@ void DisplayManager::updateCompositorDisplayState(bool on, LSMethodFunction cb ,
         LSErrorFree(&lserror);
     }
 }
+*/
 
 bool DisplayManager::orientationSensorOn ()
 {
@@ -3589,7 +3591,9 @@ void DisplayManager::displayOn(bool als)
                 notifySubscribers (DISPLAY_EVENT_ON);
         }
 
+        /*FIXME this needs rework for luna-surfacemanager
         updateCompositorDisplayState(true, &DisplayManager::displayOnCallback, this);
+        */
     }
     else {
         displayOnCallback(NULL, NULL, this);
@@ -3657,7 +3661,9 @@ void DisplayManager::displayOff()
     displayOffCallback(NULL, NULL, this);
 
     if (wasDisplayOnBefore) {
+        /* FIXME this needs updating for luna-surfacemanager
         updateCompositorDisplayState(false, NULL, NULL);
+        */
     }
 }
 

--- a/Src/base/SystemService.cpp
+++ b/Src/base/SystemService.cpp
@@ -1541,7 +1541,7 @@ static bool cbTakeScreenShot(LSHandle* lshandle, LSMessage *message, void *user_
 	screenShotHandle = lshandle;
 	LSMessageRef(message);
 	screenShotMessage = message;
-	bool result = LSCallOneReply( lshandle, "luna://org.webosports.luna/takeScreenShot", str, screenShotReplyCallback, NULL, NULL, &lserror);
+	bool result = LSCallOneReply( lshandle, "luna://com.webos.surfacemanager/captureCompositorOutput", str, screenShotReplyCallback, NULL, NULL, &lserror);
 	if (!result) {
 		g_warning("%s: Failed in takeScreenShot: %s", __PRETTY_FUNCTION__, lserror.message);
 		LSErrorFree(&lserror);


### PR DESCRIPTION
To work around errors in the logs such as:

Apr 30 09:17:09 qemux86-64 ls-hubd[233]: [] [pmlog] ls-hubd LSHUB_NOT_LSTED {"SERVICE_NAME":"org.webosports.luna","EXE":"/usr/sbin/LunaSysMgr","APP_ID":"(null)","PID":444} Service not listed in service files (cmdline: /usr/sbin/LunaSysMgr)
Apr 30 09:17:09 qemux86-64 ls-hubd[233]: [] [pmlog] ls-hubd LSHUB_NO_SERVICE {} _LSHubSendQueryNameReplyMessage: Failed Connecting to Service err_code: -4, service_name: "org.webosports.luna", unique_name: "(null)", static, fd -1

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>