### PR TITLE
luna-sysmgr.service: Update to reflect the correct name

### DIFF
--- a/files/systemd/luna-sysmgr.service
+++ b/files/systemd/luna-sysmgr.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Luna System Manager
-After=luna-sys-service.service nyx.target configurator.service
+After=luna-sys-service.service nyx.target configurator-db8.service
 Requires=luna-sys-service.service
 BindsTo=nyx.target
 


### PR DESCRIPTION
This was updated to configurator-db8 when we moved to OSE's configurator.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
