### PR TITLE
luna-sysmgr: Remove orientationSensor and displayPainting

### DIFF
--- a/Src/base/DisplayManager.cpp
+++ b/Src/base/DisplayManager.cpp
@@ -2611,13 +2611,6 @@ void DisplayManager::markBootFinished(bool finished)
 			on();
 
 		m_bootFinished = true;
-		if (currentState() == DisplayStateOn
-				|| currentState() == DisplayStateOnLocked
-				|| currentState() == DisplayStateOnPuck
-				|| currentState() == DisplayStateDockMode
-				|| (currentState() == DisplayStateDim && !Settings::LunaSettings()->turnOffAccelWhenDimmed))
-		orientationSensorOn();
-
 		// Update compass with correct lat/long
 		requestCurrentLocation();
 	}
@@ -2990,22 +2983,6 @@ void DisplayManager::updateCompositorDisplayState(bool on, LSMethodFunction cb ,
     }
 }
 */
-
-bool DisplayManager::orientationSensorOn ()
-{
-	if (!m_bootFinished)
-		return true;
-
-	HostBase::instance()->OrientationSensorOn(true);
-
-	return true;
-}
-
-bool DisplayManager::orientationSensorOff ()
-{
-    HostBase::instance()->OrientationSensorOn(false);
-    return true;
-}
 
 void DisplayManager::getBearingInfo(double& latitude, double& longitude)
 {

--- a/Src/base/DisplayManager.h
+++ b/Src/base/DisplayManager.h
@@ -157,9 +157,6 @@ public:
     void setActiveTouchpanel (bool enable);
     void setAlsDisabled (bool disable);
 
-    bool orientationSensorOn();
-    bool orientationSensorOff();
-
     bool updateNyxWithLocation(double latitude, double longitude);
 
     bool isOn() const;

--- a/Src/base/DisplayStates.cpp
+++ b/Src/base/DisplayStates.cpp
@@ -157,20 +157,6 @@ bool DisplayStateBase::isDemo()
     return dm->isDemo();
 }
 
-bool DisplayStateBase::orientationSensorOn()
-{
-    if (!dm)
-        dm = DisplayManager::instance();
-    return dm->orientationSensorOn();
-}
-
-bool DisplayStateBase::orientationSensorOff()
-{
-    if (!dm)
-        dm = DisplayManager::instance();
-    return dm->orientationSensorOff();
-}
-
 void DisplayStateBase::startInactivityTimer()
 {
     updateLastEvent();
@@ -234,20 +220,6 @@ int DisplayStateBase::getCurrentAlsRegion() {
     return ALS_REGION_INDOOR;
 }
 
-void DisplayStateBase::enablePainting() {
-#if 0
-    WindowServer::instance()->setPaintingDisabled (false);
-	AppDirectRenderingArbitrator::resume();
-#endif
-}
-
-void DisplayStateBase::disablePainting() {
-#if 0
-    WindowServer::instance()->setPaintingDisabled (true);
-	AppDirectRenderingArbitrator::suspend();
-#endif
-}
-
 void DisplayStateBase::emitDisplayStateChange(int displaySignal)
 {
     if (!dm)
@@ -295,9 +267,7 @@ void DisplayOff::enter (DisplayState state, DisplayEvent displayEvent, sptr<Even
     g_message ("%s: entering state", __PRETTY_FUNCTION__);
     if (DisplayStateOffSuspended != state)
     {
-        orientationSensorOff();
         displayOff();
-        disablePainting();
         updateLockState (DisplayLockLocked, displayEvent);
         g_debug ("Emitting DISPLAY_SIGNAL_OFF");
         emitDisplayStateChange (DISPLAY_SIGNAL_OFF);
@@ -574,9 +544,7 @@ DisplayOffOnCall::DisplayOffOnCall()
 void DisplayOffOnCall::enter (DisplayState state, DisplayEvent displayEvent, sptr<Event> event)
 {
     g_message ("%s: entering state", __PRETTY_FUNCTION__);
-    orientationSensorOff();
     displayOff();
-    disablePainting();
     emitDisplayStateChange (DISPLAY_SIGNAL_OFF_ON_CALL);
 }
 
@@ -807,11 +775,9 @@ DisplayOn::DisplayOn()
 void DisplayOn::enter (DisplayState state, DisplayEvent displayEvent, sptr<Event> event)
 {
     g_message ("%s: entering state", __PRETTY_FUNCTION__);
-    enablePainting();
     if( updateLockState (DisplayLockUnlocked, displayEvent) ) {
         g_debug ("Emitting DISPLAY_SIGNAL_ON");
         emitDisplayStateChange (DISPLAY_SIGNAL_ON);
-        orientationSensorOn();
         displayOn(false);
 
         if (displayEvent != DisplayEventApiOn)
@@ -1096,11 +1062,9 @@ DisplayOnLocked::DisplayOnLocked()
 void DisplayOnLocked::enter (DisplayState state, DisplayEvent displayEvent, sptr<Event> event)
 {
     g_message ("%s: entering state", __PRETTY_FUNCTION__);
-    enablePainting();
     updateLockState (DisplayLockLocked, displayEvent);
     g_debug ("Emitting DISPLAY_SIGNAL_ON");
     emitDisplayStateChange (DISPLAY_SIGNAL_ON);
-    orientationSensorOn();
     displayOn(false);
     startInactivityTimer();
 }
@@ -1396,10 +1360,6 @@ void DisplayDim::enter (DisplayState state, DisplayEvent displayEvent, sptr<Even
     g_message ("%s: entering state", __PRETTY_FUNCTION__);
     g_debug ("Emitting DISPLAY_SIGNAL_DIM");
     emitDisplayStateChange (DISPLAY_SIGNAL_DIM);
-    if (Settings::LunaSettings()->turnOffAccelWhenDimmed)
-        orientationSensorOff();
-    else
-        orientationSensorOn();
     displayDim();
     startInactivityTimer();
 }
@@ -1586,8 +1546,6 @@ void DisplayOnPuck::enter (DisplayState state, DisplayEvent displayEvent, sptr<E
     if( updateLockState (DisplayLockUnlocked, displayEvent) ) {
         g_debug ("Emitting DISPLAY_SIGNAL_ON");
         emitDisplayStateChange (DISPLAY_SIGNAL_ON);
-        enablePainting();
-        orientationSensorOn();
 
         if (!isOnCall())
             startInactivityTimer();
@@ -1784,7 +1742,6 @@ bool DisplayDockMode::timeoutExit()
 void DisplayDockMode::enter (DisplayState state, DisplayEvent displayEvent, sptr<Event> event)
 {
     g_message ("%s: entering state", __PRETTY_FUNCTION__);
-    orientationSensorOn();
 
     g_debug ("Emitting DISPLAY_SIGNAL_DOCK");
     emitDisplayStateChange (DISPLAY_SIGNAL_DOCK);
@@ -1802,9 +1759,6 @@ void DisplayDockMode::enter (DisplayState state, DisplayEvent displayEvent, sptr
     // if display was on, update lock window that display is in nightstand mode after dimming the display
     if (state != DisplayStateOff)
         updateLockState (DisplayLockDockMode, displayEvent);
-
-    enablePainting();
-
     startInactivityTimer();
 }
 
@@ -1931,9 +1885,7 @@ DisplayOffSuspended::DisplayOffSuspended()
 void DisplayOffSuspended::enter (DisplayState state, DisplayEvent displayEvent, sptr<Event> event)
 {
 	g_message ("%s: entering state", __PRETTY_FUNCTION__);
-    orientationSensorOff();
 	displayOff();
-	disablePainting();
 
 	if (state != DisplayStateOff && state != DisplayStateOffOnCall)
 		g_warning ("%s: entering from state %d, not a valid state to transition from!", __PRETTY_FUNCTION__, state);

--- a/Src/base/DisplayStates.h
+++ b/Src/base/DisplayStates.h
@@ -134,10 +134,6 @@ class DisplayStateBase {
 
 	bool proximityOff();
 	bool proximityOn();
-    bool orientationSensorOn();
-    bool orientationSensorOff();
-	void enablePainting();
-	void disablePainting();
 
 	void emitDisplayStateChange(int);
 


### PR DESCRIPTION
Since we're dealing with this from luna-next-cardshell now and not from luna-sysmgr. Anyway we don't have Nyx hooked up for this, so it's quite useless and causes logspam.

Oct 30 08:19:50 pinephonepro LunaSysMgr[1321]: [] [pmlog] <default-lib> NYX_OPEN_ERR {} module (nyxSensorOrientationDefault.module) does not exist in /usr/lib/nyx/modules nor in /usr/lib/nyx/modules.mock