### PR TITLE
com.palm.luna.api.json: Add API for setLockStatus

### DIFF
--- a/files/sysbus/com.palm.luna.api.json
+++ b/files/sysbus/com.palm.luna.api.json
@@ -16,6 +16,7 @@
     "com.palm.display/control/alert",
     "com.palm.display/control/getProperty",
     "com.palm.display/control/lockStatus",
+    "com.palm.display/control/setLockStatus",
     "com.palm.display/control/setProperty",
     "com.palm.display/control/setState",
     "com.palm.display/control/status",


### PR DESCRIPTION
Fixes:

Oct 31 07:04:48 pinephonepro LunaSysMgr[1192]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.webos.surfacemanager-cardshell","CATEGORY":"/control","METHOD":"setLockStatus"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
