### PR TITLE
DisplayManager: fix displayOn

### DIFF
--- a/Src/base/DisplayManager.cpp
+++ b/Src/base/DisplayManager.cpp
@@ -3571,6 +3571,7 @@ void DisplayManager::displayOn(bool als)
         /*FIXME this needs rework for luna-surfacemanager
         updateCompositorDisplayState(true, &DisplayManager::displayOnCallback, this);
         */
+        displayOnCallback(NULL, NULL, this);
     }
     else {
         displayOnCallback(NULL, NULL, this);


### PR DESCRIPTION
Until we restore the initial updateCompositorDisplayState call, let's just simply turn the display on.