### PR TITLE
DisplayManager.cpp: Fix Set call for preferences

### DIFF
--- a/Src/base/DisplayManager.cpp
+++ b/Src/base/DisplayManager.cpp
@@ -58,7 +58,7 @@
 
 #define DISPLAY_APPID "com.palm.display"
 #define URI_PREFS_GET "palm://com.palm.preferences/appProperties/Get"
-#define URI_PREFS_SET "palm://com.palm.preferences/appProperties/Set"
+#define URI_PREFS_SET "palm://com.palm.preferences/appProperties/setAppProperty"
 
 #define URI_SIGNAL_ADDMATCH "palm://com.palm.lunabus/signal/addmatch"
 #define URI_POWERD_BATTERY_SIGNAL_REQUEST "palm://com.palm.display/com/palm/power/batteryStatusQuery"


### PR DESCRIPTION
Seems that DisplayManager tries to update brightness with the wrong call:

219.036 TX  call        276             com.palm.display (TWO5GhpP)     com.palm.preferences (hRq7V8Yj)         (null)          /appProperties/Set      ï¿½{"appId":"com.palm.display","key":"maximumBrightness","value":{"maximumBrightness":100}}

Fixes: Dec 01 06:14:04 pinephonepro luna-prefs-service[1290]: [] [pmlog] <default-lib> LS_NO_METH {"METHOD":"Set"} Couldn't find method: Set