### PR TITLE
com.palm.display: Fix LS2 permission errors

### DIFF
--- a/files/sysbus/com.palm.luna.perm.json
+++ b/files/sysbus/com.palm.luna.perm.json
@@ -42,7 +42,9 @@
         "database.management",
         "database.operation",
         "location-service.operation",
-        "telephony.management"
+        "telephony.management",
+        "preferences.systempropertyquery",
+        "preferences.operation"
     ],
     "com.palm.keys": [
         "database.management",


### PR DESCRIPTION
Fixes: Dec 01 16:10:53 pinephonepro luna-prefs-service[1317]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.display","CATEGORY":"/appProperties","METHOD":"setAppProperty"} Service security groups don't allow method call.