### PR TITLE
SystemService.cpp: Try to bring back novacom

### DIFF
--- a/Src/base/SystemService.cpp
+++ b/Src/base/SystemService.cpp
@@ -359,8 +359,7 @@ void SystemService::startService()
     if (!result)
         goto Done;
 
-    //We don't have com.palm.accountservices available, so it doesn't make much sense to do the call to postNovacomStatus either
-    //postNovacomStatus();
+    postNovacomStatus();
 
 Done:
 
@@ -4832,13 +4831,13 @@ void SystemService::postNovacomStatus()
         novacomEnabled = true;
 
     result = LSCall(m_service,
-                    "palm://com.palm.accountservices/updateDeviceProperties",
+                    "luna://com.webos.service.systemservice/setPreferences",
                     novacomEnabled ?
                     "{\"novacomEnabled\":\"true\"}" :
                     "{\"novacomEnabled\":\"false\"}",
                     NULL, NULL, NULL, &lsError);
     if (!result) {
-        g_warning("Failed to call palm://com.palm.accountservices/updateDeviceProperties: %s",
+        g_warning("Failed to call luna://com.webos.service.systemservice/setPreferences: %s",
                   lsError.message);
         LSErrorFree(&lsError);
     }


### PR DESCRIPTION
Why not, the more connection options the better :) This will allow WebOSQuickInstall and possibly ares-cli and webOS SDK to work again :)

com.palm.accountservices/updateDeviceProperties calls systemservice/setPreferences in the background simply. So instead of going via the not available to LuneOS accountservices we use a direct call to systemservice instead. 

The code in the account services for reference:

`var UpdateDevicePropsCommandAssistant =  Class.create({

	run: function(future){
		var args = this.controller.args;
		
		if (!args) {
			PalmProfileUtil.sendError(future, "INVALID_REQUEST", "No input params");
		}
		this.updatePrefs(future, args);
	},
	
	updatePrefs: function (future, args) {
			var prefsFuture = PalmCall.call("palm://com.palm.systemservice/", "setPreferences", args);	
			prefsFuture.then(this, function() { 
				return PalmProfileUtil.handleThenResult(this, "setPreferences", future, prefsFuture, function(){
					var result = prefsFuture.result;
					
					if(result.returnValue && result.returnValue === true) {
						// successfully updated
						ServiceLog.log("------------ prefsFuture result ------------"+result.returnValue);
						future.result = {"returnValue": true};
					} else {
						PalmProfileUtil.sendError(future, "UPDATE_ERROR", "Could not update device properties");
					}
				});	
			})

	}
});`
