### PR TITLE
luna-sysmgr: Fix calls to power and sleepd service

### DIFF
--- a/Src/base/DisplayManager.cpp
+++ b/Src/base/DisplayManager.cpp
@@ -51,8 +51,8 @@
 #include <lunaprefs.h>
 #endif
 
-#define URI_POWERD_ACTIVITY_START  "palm://com.palm.power/com/palm/power/activityStart"
-#define URI_POWERD_ACTIVITY_END    "palm://com.palm.power/com/palm/power/activityEnd"
+#define URI_POWERD_ACTIVITY_START  "palm://com.webos.service.sleep/com/palm/power/activityStart"
+#define URI_POWERD_ACTIVITY_END    "palm://com.webos.service.sleep/com/palm/power/activityEnd"
 #define JSON_POWERD_ACTIVITY_START "{\"id\":\"com.palm.display-lock.timer\",\"duration_ms\":%i}"
 #define JSON_POWERD_ACTIVITY_END   "{\"id\":\"com.palm.display-lock.timer\"}"
 
@@ -351,7 +351,7 @@ DisplayManager::DisplayManager()
     if (!qemu)
     {
         // check if the service is up
-        result = LSRegisterServerStatusEx(m_service, "com.palm.power",
+        result = LSRegisterServerStatusEx(m_service, "com.webos.service.sleep",
                 DisplayManager::powerdServiceNotification, this, NULL, &lserror);
         if (!result)
         {
@@ -3756,7 +3756,7 @@ void DisplayManager::wakeupDevice(const char *reason)
 
     LSErrorInit(&lserror);
     payload = g_strdup_printf("{\"reason\":\"%s\"}", reason);
-    if (!LSCallOneReply (m_service, "luna://com.palm.sleep/com/palm/power/resume", payload, NULL, NULL, NULL, &lserror)) {
+    if (!LSCallOneReply (m_service, "luna://com.webos.service.sleep/com/palm/power/resume", payload, NULL, NULL, NULL, &lserror)) {
         LSErrorPrint(&lserror, stderr);
         LSErrorFree(&lserror);
     }

--- a/Src/base/SuspendBlocker.cpp
+++ b/Src/base/SuspendBlocker.cpp
@@ -65,7 +65,7 @@ SuspendBlockerBase::SuspendBlockerBase(GMainLoop* mainLoop)
     // Register with bus to known when powerd is up
     callService(m_service, SuspendBlockerBase::cbPowerdUp,
                 "palm://com.palm.lunabus/signal/registerServerStatus",
-                "{\"serviceName\":\"com.palm.power\"}");
+                "{\"serviceName\":\"com.webos.service.sleep\"}");
 
     callService(m_service, SuspendBlockerBase::cbSuspendRequest,
                 "palm://com.palm.bus/signal/addmatch",
@@ -99,7 +99,7 @@ bool SuspendBlockerBase::cbSuspendRequest(LSHandle* sh, LSMessage* msg, void* ct
                  val ? "true" : "false", s->m_id);
         
         s->callService(s->m_service, NULL,
-                       "palm://com.palm.power/com/palm/power/suspendRequestAck",
+                       "palm://com.webos.service.sleep/com/palm/power/suspendRequestAck",
                        message);
 
         free(message);
@@ -121,7 +121,7 @@ bool SuspendBlockerBase::cbPrepareSuspend(LSHandle* sh, LSMessage* msg, void* ct
                  val ? "true" : "false", s->m_id);
 
         s->callService(s->m_service, NULL,
-                       "palm://com.palm.power/com/palm/power/prepareSuspendAck",
+                       "palm://com.webos.service.sleep/com/palm/power/prepareSuspendAck",
                        message);
 
         // FIXME: Temporarily disable. We are seeing hangs with the new LS
@@ -216,7 +216,7 @@ bool SuspendBlockerBase::cbPowerdUp(LSHandle* sh, LSMessage* msg, void* ctx)
                          s->m_name);
             
                 s->callService(s->m_service, SuspendBlockerBase::cbIdentify,
-                               "palm://com.palm.power/com/palm/power/identify",
+                               "palm://com.webos.service.sleep/com/palm/power/identify",
                                message);
                 free(message);
             }
@@ -285,7 +285,7 @@ void SuspendBlockerBase::registerSuspendRequest()
     char* message = 0;
     asprintf(&message, "{\"register\":true,\"clientId\":\"%s\"}", m_id);
     callService(m_service, NULL,
-                "palm://com.palm.power/com/palm/power/suspendRequestRegister",
+                "palm://com.webos.service.sleep/com/palm/power/suspendRequestRegister",
                 message);
     free(message);      
 }
@@ -301,7 +301,7 @@ void SuspendBlockerBase::registerPrepareSuspend()
     char* message = 0;
     asprintf(&message, "{\"register\":true,\"clientId\":\"%s\"}", m_id);     
     callService(m_service, NULL,
-                "palm://com.palm.power/com/palm/power/prepareSuspendRegister",
+                "palm://com.webos.service.sleep/com/palm/power/prepareSuspendRegister",
                 message);
     free(message);                
 }

--- a/Src/base/SystemService.cpp
+++ b/Src/base/SystemService.cpp
@@ -866,7 +866,7 @@ void SystemService::shutdownDevice()
     json_object* json = json_object_new_object();
     json_object_object_add(json, "reason", json_object_new_string("PowerOff Selected by User"));
 
-    if (!LSCall(m_service, "palm://com.palm.power/shutdown/machineOff",
+    if (!LSCall(m_service, "palm://com.webos.service.power/shutdown/machineOff",
                 json_object_to_json_string(json),
                 NULL, NULL, NULL, &lsError))
     {


### PR DESCRIPTION
Since we now fully migrated, we need to update these calls. Let's use the proper webos names ones instead of legacy Palm ones.

https://github.com/webOS-ports/meta-webos-ports/commit/db6f3234cf42221f33a73c77eda2737110e52f78