### PR TITLE
luna-sysmgr: Add ACG groups file

### DIFF
--- a/files/sysbus/com.palm.luna.groups.json
+++ b/files/sysbus/com.palm.luna.groups.json
@@ -1,0 +1,4 @@
+{
+ "allowedNames": ["com.palm.lunastats", "com.palm.nativealertmanager", "com.palm.systemmanager", "com.palm.systemmanager-keymanager", "com.palm.systemmanager-prefs-*", "com.palm.systemmanager-localeprefs-*", "com.palm.vibrate", "com.palm.ambientLightSensor", "com.palm.display", "com.palm.keys", "com.palm.sysMgrDataBackup", "com.palm.eventreporter.LunaSysMgr", "com.palm.eventreporter.WebAppMgr", "com.palm.eventreporter.LunaAppManager", "com.palm.luna-*", "org.webosports.bootmgr", "com.palm.SuspendBlocker*"],
+ "luna-sysmgr.operation": ["dev"]
+}


### PR DESCRIPTION
Fixes:

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: Found 34 group(s) that appear only in api-permissions.d, consider define them in groups.d
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: === LIST BEGIN: Groups used in api-permissions.d but not defined in groups.d ===
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   luna-sysmgr.operation