### PR TITLE
com.palm.luna.perm.json: powerd.management -> sleep.management

### DIFF
--- a/files/sysbus/com.palm.luna.perm.json
+++ b/files/sysbus/com.palm.luna.perm.json
@@ -73,6 +73,6 @@
         "location-service.operation"
     ],
     "com.palm.SuspendBlocker*": [
-        "powerd.management"
+        "sleep.management"
     ]
 }


### PR DESCRIPTION
The calls by com.palm.SuspendBlocker (https://github.com/webOS-ports/luna-sysmgr/blob/webOS-ports/master/Src/base/SuspendBlocker.cpp#L68) are to APIs provided by sleepd now in sleep.management group.