### PR TITLE
com.palm.luna.perm.json: Add permissions for systemsettings.management

### DIFF
--- a/files/sysbus/com.palm.luna.perm.json
+++ b/files/sysbus/com.palm.luna.perm.json
@@ -14,7 +14,8 @@
     "com.palm.systemmanager": [
         "database.management",
         "database.operation",
-        "telephony.management"
+        "telephony.management",
+        "systemsettings.management"
     ],
     "com.palm.systemmanager-keymanager": [
         "database.management",


### PR DESCRIPTION
Fixes:

Apr 28 19:42:48 pinephonepro LunaSysService[654]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.systemmanager","CATEGORY":"/","METHOD":"setPreferences"} Service security groups don't allow method call.