### PR TITLE
Fix memory leaks in destructors to reduce memory consumption

### DIFF
--- a/Src/base/DisplayManager.cpp
+++ b/Src/base/DisplayManager.cpp
@@ -467,7 +467,7 @@ void DisplayManager::clearStates()
     delete m_displayStates[DisplayStateOnPuck];
     delete m_displayStates[DisplayStateDockMode];
     delete m_displayStates[DisplayStateOffSuspended];
-    memset (m_displayStates, 0, sizeof (m_displayStates));
+    memset(m_displayStates, 0, sizeof(DisplayStateBase*) * DisplayStateMax);
     m_currentState = NULL;
 }
 
@@ -2571,16 +2571,46 @@ done:
 
 DisplayManager::~DisplayManager()
 {
+    // Stop timers first
+    if (m_activity) {
+        m_activity->stop();
+        delete m_activity;
+        m_activity = NULL;
+    }
+    if (m_power) {
+        m_power->stop();
+        delete m_power;
+        m_power = NULL;
+    }
+    if (m_slider) {
+        m_slider->stop();
+        delete m_slider;
+        m_slider = NULL;
+    }
+    if (m_alertTimer) {
+        m_alertTimer->stop();
+        delete m_alertTimer;
+        m_alertTimer = NULL;
+    }
+
+    // Clean up AmbientLightSensor
+    delete m_als;
+    m_als = NULL;
+
+    // Clean up display states
+    clearStates();
+    delete[] m_displayStates;
+    m_displayStates = NULL;
+
+    // Unregister Luna service
     LSError lserror;
     LSErrorInit(&lserror);
-    bool result;
-
-    result = LSUnregister(m_service, &lserror);
-    if (!result)
-    {
-        g_message ("%s: failed at %s with message %s", __FUNCTION__, lserror.func, lserror.message);
+    if (!LSUnregister(m_service, &lserror)) {
+        g_message("%s: failed at %s with message %s", __FUNCTION__, lserror.func, lserror.message);
         LSErrorFree(&lserror);
     }
+
+    m_instance = NULL;
 }
 
 void DisplayManager::slotEmergencyMode (bool enable)

--- a/Src/base/EASPolicyManager.cpp
+++ b/Src/base/EASPolicyManager.cpp
@@ -107,7 +107,9 @@ EASPolicyManager::EASPolicyManager()
 
 EASPolicyManager::~EASPolicyManager()
 {
-    s_instance = 0;
+    delete m_aggregate;
+    m_aggregate = NULL;
+    s_instance = NULL;
 }
 
 
@@ -502,6 +504,8 @@ bool EASPolicyManager::importOldPolicySettings()
         EASPolicy* p = new EASPolicy;
         if(p->fromJSON(root))
             m_aggregate->merge (p);
+        delete p;
+        p = NULL;
     }
     else if (json_object_get_int(prop) == 2) {
 

--- a/Src/base/Security.cpp
+++ b/Src/base/Security.cpp
@@ -70,7 +70,13 @@ Security::Security()
 
 Security::~Security()
 {
-    s_instance = 0;
+    LSError lserror;
+    LSErrorInit(&lserror);
+    if (m_service && !LSUnregister(m_service, &lserror)) {
+        g_message("%s: failed to unregister: %s", __FUNCTION__, lserror.message);
+        LSErrorFree(&lserror);
+    }
+    s_instance = NULL;
 }
 
 void Security::registerService()

--- a/Src/base/SuspendBlocker.cpp
+++ b/Src/base/SuspendBlocker.cpp
@@ -83,7 +83,37 @@ SuspendBlockerBase::SuspendBlockerBase(GMainLoop* mainLoop)
 
 SuspendBlockerBase::~SuspendBlockerBase()
 {
-    // Shouldn't reach here
+    // Free allocated strings
+    if (m_name) {
+        free(m_name);
+        m_name = NULL;
+    }
+    if (m_id) {
+        free(m_id);
+        m_id = NULL;
+    }
+
+    // Unregister Luna services
+    LSError lserror;
+    LSErrorInit(&lserror);
+
+    if (m_nestedService && !LSUnregister(m_nestedService, &lserror)) {
+        LSErrorFree(&lserror);
+    }
+    LSErrorInit(&lserror);
+    if (m_service && !LSUnregister(m_service, &lserror)) {
+        LSErrorFree(&lserror);
+    }
+
+    // Clean up GLib resources
+    if (m_nestedLoop) {
+        g_main_loop_unref(m_nestedLoop);
+        m_nestedLoop = NULL;
+    }
+    if (m_nestedCtxt) {
+        g_main_context_unref(m_nestedCtxt);
+        m_nestedCtxt = NULL;
+    }
 }
 
 bool SuspendBlockerBase::cbSuspendRequest(LSHandle* sh, LSMessage* msg, void* ctx)

--- a/Src/base/SystemService.cpp
+++ b/Src/base/SystemService.cpp
@@ -263,8 +263,8 @@ SystemService::SystemService()
 
 SystemService::~SystemService()
 {
-    // Should never reach here
-    s_instance = 0;
+    stopService();
+    s_instance = NULL;
 }
 
 void SystemService::init()


### PR DESCRIPTION
The destructors in several singleton classes were not properly cleaning up allocated resources, causing memory leaks that contributed to ~850MB memory consumption and eventual OOM kills.

DisplayManager.cpp:
- Add cleanup for Timer objects (m_activity, m_power, m_slider, m_alertTimer) by stopping and deleting them
- Delete AmbientLightSensor (m_als)
- Call clearStates() and delete[] m_displayStates array
- Fix clearStates() memset bug: sizeof(m_displayStates) only returned pointer size, not array size. Changed to use DisplayStateMax
- Reset m_instance to NULL

EASPolicyManager.cpp:
- Delete m_aggregate EASPolicy object in destructor
- Fix memory leak in importOldPolicySettings(): version 1 migration path was not deleting EASPolicy after merge (version 2 path did)

Security.cpp:
- Add LSUnregister() call for m_service handle in destructor

SuspendBlocker.cpp:
- Free m_name and m_id strings (allocated via asprintf/strdup)
- Unregister m_nestedService and m_service Luna handles
- Unref m_nestedLoop and m_nestedCtxt GLib resources

SystemService.cpp:
- Call stopService() in destructor to properly unregister Luna service